### PR TITLE
ECS PR #3: Network serialization from ECS

### DIFF
--- a/server/src/ecs/index.ts
+++ b/server/src/ecs/index.ts
@@ -32,3 +32,6 @@ export {
 
 // Systems
 export * from './systems';
+
+// Serialization (ECS to network message conversion)
+export * from './serialization';

--- a/server/src/ecs/serialization/detectionSerializer.ts
+++ b/server/src/ecs/serialization/detectionSerializer.ts
@@ -1,0 +1,205 @@
+// ============================================
+// Detection Serialization
+// Build detection messages for multi-cell chemical sensing
+// ============================================
+
+import type { World } from '../World';
+import type { EntityId } from '../types';
+import { Components, Tags } from '../types';
+import { getSocketIdByEntity, getStringIdByEntity } from '../factories';
+import type {
+  PositionComponent,
+  EnergyComponent,
+  StageComponent,
+  NutrientComponent,
+} from '../components';
+import type { DetectedEntity, DetectionUpdateMessage } from '@godcell/shared';
+import { EvolutionStage } from '@godcell/shared';
+
+/**
+ * Calculate distance between two positions.
+ */
+function distance(p1: { x: number; y: number }, p2: { x: number; y: number }): number {
+  const dx = p1.x - p2.x;
+  const dy = p1.y - p2.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Get all entities within detection range of a position.
+ * Used for multi-cell chemical sensing.
+ */
+export interface DetectedEntityData {
+  entity: EntityId;
+  position: { x: number; y: number };
+  entityType: 'player' | 'nutrient' | 'swarm';
+  stage?: EvolutionStage;
+  stringId: string;
+}
+
+/**
+ * Find all players within detection range (for chemical sensing).
+ * Excludes dead players and self.
+ */
+export function detectPlayersInRange(
+  world: World,
+  sensorEntity: EntityId,
+  sensorPosition: { x: number; y: number },
+  detectionRadius: number
+): DetectedEntityData[] {
+  const detected: DetectedEntityData[] = [];
+
+  world.forEachWithTag(Tags.Player, (entity) => {
+    // Don't detect yourself
+    if (entity === sensorEntity) return;
+
+    // Skip dead players
+    const energy = world.getComponent<EnergyComponent>(entity, Components.Energy);
+    if (!energy || energy.current <= 0) return;
+
+    // Check distance
+    const pos = world.getComponent<PositionComponent>(entity, Components.Position);
+    if (!pos) return;
+
+    const dist = distance(sensorPosition, pos);
+    if (dist <= detectionRadius) {
+      const stage = world.getComponent<StageComponent>(entity, Components.Stage);
+      const socketId = getSocketIdByEntity(entity);
+
+      if (socketId) {
+        detected.push({
+          entity,
+          position: { x: pos.x, y: pos.y },
+          entityType: 'player',
+          stage: stage?.stage,
+          stringId: socketId,
+        });
+      }
+    }
+  });
+
+  return detected;
+}
+
+/**
+ * Find all nutrients within detection range.
+ */
+export function detectNutrientsInRange(
+  world: World,
+  sensorPosition: { x: number; y: number },
+  detectionRadius: number
+): DetectedEntityData[] {
+  const detected: DetectedEntityData[] = [];
+
+  world.forEachWithTag(Tags.Nutrient, (entity) => {
+    const pos = world.getComponent<PositionComponent>(entity, Components.Position);
+    if (!pos) return;
+
+    const dist = distance(sensorPosition, pos);
+    if (dist <= detectionRadius) {
+      const stringId = getStringIdByEntity(entity);
+
+      if (stringId) {
+        detected.push({
+          entity,
+          position: { x: pos.x, y: pos.y },
+          entityType: 'nutrient',
+          stringId,
+        });
+      }
+    }
+  });
+
+  return detected;
+}
+
+/**
+ * Find all swarms within detection range.
+ */
+export function detectSwarmsInRange(
+  world: World,
+  sensorPosition: { x: number; y: number },
+  detectionRadius: number
+): DetectedEntityData[] {
+  const detected: DetectedEntityData[] = [];
+
+  world.forEachWithTag(Tags.Swarm, (entity) => {
+    const pos = world.getComponent<PositionComponent>(entity, Components.Position);
+    if (!pos) return;
+
+    const dist = distance(sensorPosition, pos);
+    if (dist <= detectionRadius) {
+      const stringId = getStringIdByEntity(entity);
+
+      if (stringId) {
+        detected.push({
+          entity,
+          position: { x: pos.x, y: pos.y },
+          entityType: 'swarm',
+          stringId,
+        });
+      }
+    }
+  });
+
+  return detected;
+}
+
+/**
+ * Build a DetectionUpdateMessage for a player entity.
+ * Returns null if the player doesn't have detection capability (single-cell).
+ */
+export function buildDetectionUpdateMessage(
+  world: World,
+  playerEntity: EntityId,
+  detectionRadius: number
+): { socketId: string; message: DetectionUpdateMessage } | null {
+  // Check player is alive
+  const energy = world.getComponent<EnergyComponent>(playerEntity, Components.Energy);
+  if (!energy || energy.current <= 0) return null;
+
+  // Get player stage - only multi-cells and above can detect
+  const stageComp = world.getComponent<StageComponent>(playerEntity, Components.Stage);
+  if (!stageComp || stageComp.stage === EvolutionStage.SINGLE_CELL) return null;
+
+  // Get player position
+  const pos = world.getComponent<PositionComponent>(playerEntity, Components.Position);
+  if (!pos) return null;
+
+  // Get socket ID for sending
+  const socketId = getSocketIdByEntity(playerEntity);
+  if (!socketId) return null;
+
+  // Detect all nearby entities
+  const detectedPlayers = detectPlayersInRange(world, playerEntity, pos, detectionRadius);
+  const detectedNutrients = detectNutrientsInRange(world, pos, detectionRadius);
+  const detectedSwarms = detectSwarmsInRange(world, pos, detectionRadius);
+
+  // Convert to network format
+  const detected: DetectedEntity[] = [
+    ...detectedPlayers.map((d) => ({
+      id: d.stringId,
+      position: d.position,
+      entityType: d.entityType,
+      stage: d.stage,
+    })),
+    ...detectedNutrients.map((d) => ({
+      id: d.stringId,
+      position: d.position,
+      entityType: d.entityType as 'nutrient',
+    })),
+    ...detectedSwarms.map((d) => ({
+      id: d.stringId,
+      position: d.position,
+      entityType: d.entityType as 'swarm',
+    })),
+  ];
+
+  return {
+    socketId,
+    message: {
+      type: 'detectionUpdate',
+      detected,
+    },
+  };
+}

--- a/server/src/ecs/serialization/index.ts
+++ b/server/src/ecs/serialization/index.ts
@@ -1,0 +1,7 @@
+// ============================================
+// ECS Serialization
+// Converts ECS entities to network message formats
+// ============================================
+
+export * from './playerSerializer';
+export * from './detectionSerializer';

--- a/server/src/ecs/serialization/playerSerializer.ts
+++ b/server/src/ecs/serialization/playerSerializer.ts
@@ -1,0 +1,91 @@
+// ============================================
+// Player Serialization
+// Convert player entities to network formats
+// ============================================
+
+import type { World } from '../World';
+import type { EntityId } from '../types';
+import { Components, Tags } from '../types';
+import { getSocketIdByEntity } from '../factories';
+import type { PositionComponent, EnergyComponent, StageComponent } from '../components';
+import type { EnergyUpdateMessage } from '@godcell/shared';
+
+/**
+ * Get all player entities from ECS.
+ * Returns entities with the Player tag.
+ */
+export function getPlayerEntities(world: World): EntityId[] {
+  return world.getEntitiesWithTag(Tags.Player);
+}
+
+/**
+ * Get all living player entities (energy > 0).
+ */
+export function getLivingPlayerEntities(world: World): EntityId[] {
+  const players: EntityId[] = [];
+
+  world.forEachWithTag(Tags.Player, (entity) => {
+    const energy = world.getComponent<EnergyComponent>(entity, Components.Energy);
+    if (energy && energy.current > 0) {
+      players.push(entity);
+    }
+  });
+
+  return players;
+}
+
+/**
+ * Build EnergyUpdateMessage for a player entity.
+ * Returns null if the player is dead or components are missing.
+ */
+export function buildEnergyUpdateMessage(
+  world: World,
+  entity: EntityId
+): EnergyUpdateMessage | null {
+  const energy = world.getComponent<EnergyComponent>(entity, Components.Energy);
+  if (!energy || energy.current <= 0) return null;
+
+  const socketId = getSocketIdByEntity(entity);
+  if (!socketId) return null;
+
+  return {
+    type: 'energyUpdate',
+    playerId: socketId,
+    energy: energy.current,
+  };
+}
+
+/**
+ * Build all energy update messages for living players.
+ */
+export function buildAllEnergyUpdates(world: World): EnergyUpdateMessage[] {
+  const messages: EnergyUpdateMessage[] = [];
+
+  world.forEachWithTag(Tags.Player, (entity) => {
+    const msg = buildEnergyUpdateMessage(world, entity);
+    if (msg) {
+      messages.push(msg);
+    }
+  });
+
+  return messages;
+}
+
+/**
+ * Get player position from ECS.
+ * Returns undefined if entity doesn't have position.
+ */
+export function getPlayerPosition(
+  world: World,
+  entity: EntityId
+): { x: number; y: number } | undefined {
+  return world.getComponent<PositionComponent>(entity, Components.Position);
+}
+
+/**
+ * Get player stage from ECS.
+ */
+export function getPlayerStage(world: World, entity: EntityId) {
+  const stage = world.getComponent<StageComponent>(entity, Components.Stage);
+  return stage?.stage;
+}

--- a/server/src/ecs/systems/NetworkBroadcastSystem.ts
+++ b/server/src/ecs/systems/NetworkBroadcastSystem.ts
@@ -2,27 +2,109 @@
 // Network Broadcast System
 // Handles all network broadcasts at end of tick
 // ============================================
+//
+// This system demonstrates the ECS approach to network serialization:
+// - Queries entities directly from ECS World
+// - Uses serialization utilities to build messages
+// - Owns its own throttle state (tick counters)
+//
+// The drain state broadcast still uses GameContext because that
+// state (activeDamageThisTick, pseudopodHitDecays) hasn't been
+// migrated to ECS yet.
 
 import type { System } from './types';
 import type { GameContext } from './GameContext';
+import { GAME_CONFIG } from '@godcell/shared';
+import {
+  buildAllEnergyUpdates,
+  buildDetectionUpdateMessage,
+} from '../serialization';
+
+// Throttle intervals (in ticks)
+// Energy updates: ~6 times/sec at 60fps
+const ENERGY_UPDATE_INTERVAL = 10;
+// Detection updates: ~4 times/sec at 60fps
+const DETECTION_UPDATE_INTERVAL = 15;
 
 /**
  * NetworkBroadcastSystem - Handles end-of-tick broadcasts
  *
- * This system runs last and broadcasts:
- * - Energy updates (throttled)
- * - Detection updates (for multi-cells)
- * - Drain state updates
+ * Broadcasts:
+ * - Energy updates (throttled) - uses ECS queries
+ * - Detection updates (throttled) - uses ECS queries
+ * - Drain state updates - uses GameContext (legacy)
  *
- * Currently wraps existing broadcast functions.
- * Future: Build broadcast messages directly from ECS state.
+ * This system runs last (highest priority number).
  */
 export class NetworkBroadcastSystem implements System {
   readonly name = 'NetworkBroadcastSystem';
 
+  // Tick counters for throttling
+  private energyUpdateTicks = 0;
+  private detectionUpdateTicks = 0;
+
   update(ctx: GameContext): void {
-    ctx.broadcastEnergyUpdates();
-    ctx.broadcastDetectionUpdates();
+    this.broadcastEnergyUpdates(ctx);
+    this.broadcastDetectionUpdates(ctx);
+    this.broadcastDrainState(ctx);
+  }
+
+  /**
+   * Broadcast energy updates to all clients (throttled).
+   * Uses ECS queries to get player energy data.
+   */
+  private broadcastEnergyUpdates(ctx: GameContext): void {
+    this.energyUpdateTicks++;
+
+    if (this.energyUpdateTicks >= ENERGY_UPDATE_INTERVAL) {
+      this.energyUpdateTicks = 0;
+
+      // Build energy messages from ECS
+      const messages = buildAllEnergyUpdates(ctx.world);
+
+      // Broadcast each message
+      for (const msg of messages) {
+        ctx.io.emit('energyUpdate', msg);
+      }
+    }
+  }
+
+  /**
+   * Broadcast detection updates to multi-cell+ players (throttled).
+   * Each player gets their own private detection message.
+   * Uses ECS queries for detection range calculations.
+   */
+  private broadcastDetectionUpdates(ctx: GameContext): void {
+    this.detectionUpdateTicks++;
+
+    if (this.detectionUpdateTicks >= DETECTION_UPDATE_INTERVAL) {
+      this.detectionUpdateTicks = 0;
+
+      const detectionRadius = GAME_CONFIG.MULTI_CELL_DETECTION_RADIUS;
+
+      // Iterate all players and build detection messages
+      ctx.world.forEachWithTag('player', (entity) => {
+        const result = buildDetectionUpdateMessage(ctx.world, entity, detectionRadius);
+
+        if (result) {
+          // Send to specific socket (private information)
+          const socket = ctx.io.sockets.sockets.get(result.socketId);
+          if (socket) {
+            socket.emit('detectionUpdate', result.message);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Broadcast drain state updates to clients.
+   * Still uses GameContext for legacy state (activeDamage, swarm drains).
+   *
+   * This will be migrated to ECS once damage tracking moves to components.
+   */
+  private broadcastDrainState(ctx: GameContext): void {
+    // Delegate to legacy function for now
     ctx.broadcastDrainState();
   }
 }


### PR DESCRIPTION
## Summary
- Add ECS serialization module with player and detection serializers
- Refactor NetworkBroadcastSystem to query ECS directly for energy/detection broadcasts
- System now owns its throttle state instead of module-level variables

## Test plan
- [x] Server builds without type errors
- [x] Server runs with all systems registered
- [x] Game mechanics work (bots fighting, evolving, dying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)