### PR TITLE
Add jitter buffer and fix swarm SLERP interpolation

### DIFF
--- a/client/src/core/net/SnapshotBuffer.ts
+++ b/client/src/core/net/SnapshotBuffer.ts
@@ -1,0 +1,260 @@
+// ============================================
+// SnapshotBuffer - Jitter Buffer for Smooth Movement
+// ============================================
+// Buffers incoming position snapshots and plays them back with a delay
+// to absorb network jitter and provide smooth interpolation.
+//
+// Timeline visualization:
+//   Server sends: ──●──●──●──●──●──●──●──●──●──●──►
+//                       ↓ network jitter
+//   Client receives: ──●───●●────●──●●●────●──●───►
+//                       ↓ buffer (100ms delay)
+//   Client renders: ────────●──●──●──●──●──●──●──►  (smooth)
+// ============================================
+
+/**
+ * A single position snapshot from the server.
+ */
+export interface Snapshot {
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+  serverTime: number; // Server timestamp (ms)
+  clientTime: number; // When we received it (performance.now())
+}
+
+/**
+ * Buffer statistics for diagnostics.
+ */
+export interface BufferStats {
+  entityCount: number; // Number of entities being buffered
+  avgOccupancy: number; // Average snapshots per entity
+  underrunCount: number; // Times buffer was empty when queried
+  currentDelay: number; // Current buffer delay setting (ms)
+}
+
+/**
+ * SnapshotBuffer - Ring buffer per entity for delayed playback.
+ *
+ * Instead of immediately applying server positions, we buffer them
+ * and play back from `now - bufferDelay`. This absorbs network jitter
+ * by always having data ahead of playback time.
+ *
+ * Key insight: We interpolate based on SERVER timestamps (evenly spaced at 16ms)
+ * not client arrival times (bursty due to network jitter). This gives smooth
+ * playback even when packets arrive in bursts.
+ */
+export class SnapshotBuffer {
+  // Per-entity snapshot buffers (ring buffer behavior via slice)
+  private buffers: Map<string, Snapshot[]> = new Map();
+
+  // Configuration
+  private maxSnapshots = 30; // ~500ms at 60Hz server tick
+  private bufferDelay = 80; // ms - tunable, balances smoothness vs latency
+
+  // Clock offset estimation (client time - server time)
+  // Updated on each received packet to track drift
+  private clockOffsets: Map<string, number> = new Map();
+
+  // Statistics
+  private underrunCount = 0;
+
+  // Debug logging throttle
+  private _lastCase2Log: Record<string, number> = {};
+  private _loggedPlayerInterp = false;
+
+  /**
+   * Push a new snapshot into the buffer for an entity.
+   * Maintains chronological order and trims old snapshots.
+   * Also updates clock offset estimation for server-time interpolation.
+   */
+  push(entityId: string, snapshot: Snapshot): void {
+    let buffer = this.buffers.get(entityId);
+    if (!buffer) {
+      buffer = [];
+      this.buffers.set(entityId, buffer);
+    }
+
+    // Add snapshot (should already be in order from server)
+    buffer.push(snapshot);
+
+    // Update clock offset (clientTime - serverTime)
+    // Use exponential moving average to smooth out variations
+    const newOffset = snapshot.clientTime - snapshot.serverTime;
+    const prevOffset = this.clockOffsets.get(entityId);
+    if (prevOffset !== undefined) {
+      // EMA with alpha=0.1 for smooth tracking
+      this.clockOffsets.set(entityId, prevOffset * 0.9 + newOffset * 0.1);
+    } else {
+      this.clockOffsets.set(entityId, newOffset);
+    }
+
+    // Trim old snapshots (keep buffer size bounded)
+    if (buffer.length > this.maxSnapshots) {
+      buffer.shift();
+    }
+  }
+
+  /**
+   * Get interpolated position for an entity at the given playback time.
+   *
+   * Key insight: We interpolate based on SERVER timestamps, not client arrival times.
+   * Server sends at consistent 16ms intervals, so serverTime is evenly spaced.
+   * Client arrival times are bursty due to network jitter.
+   *
+   * By interpolating on serverTime, we get smooth playback even when packets
+   * arrive in bursts.
+   *
+   * @param entityId - The entity to query
+   * @param playbackTime - The target time in client time (typically now - bufferDelay)
+   */
+  getInterpolated(entityId: string, playbackTime: number): Snapshot | null {
+    const buffer = this.buffers.get(entityId);
+    if (!buffer || buffer.length === 0) {
+      this.underrunCount++;
+      return null;
+    }
+
+    // Convert client playbackTime to equivalent server time
+    const clockOffset = this.clockOffsets.get(entityId) ?? 0;
+    const targetServerTime = playbackTime - clockOffset;
+
+    // Find two snapshots bracketing targetServerTime (using serverTime)
+    // Buffer is sorted by arrival order, which should match serverTime order
+    let before: Snapshot | null = null;
+    let after: Snapshot | null = null;
+
+    for (let i = 0; i < buffer.length; i++) {
+      const snap = buffer[i];
+      if (snap.serverTime <= targetServerTime) {
+        before = snap;
+      } else {
+        after = snap;
+        break;
+      }
+    }
+
+    // Case 1: No data before targetServerTime - buffer underrun
+    if (!before) {
+      this.underrunCount++;
+      // Return oldest snapshot as fallback
+      return buffer[0];
+    }
+
+    // Case 2: No data after targetServerTime - use most recent
+    // This happens when buffer is running low (need more delay)
+    if (!after) {
+      return before;
+    }
+
+    // DEBUG: Log successful interpolation for first player (once)
+    if (entityId.startsWith('player') && !this._loggedPlayerInterp) {
+      console.log(`[BUFFER_DEBUG] ${entityId} INTERPOLATING: targetST=${targetServerTime.toFixed(0)} between ${before.serverTime.toFixed(0)} and ${after.serverTime.toFixed(0)}`);
+      this._loggedPlayerInterp = true;
+    }
+
+    // Case 3: Interpolate between before and after based on serverTime
+    // ServerTime is evenly spaced (~16ms intervals), giving smooth interpolation
+    const t1 = before.serverTime;
+    const t2 = after.serverTime;
+    const dt = t2 - t1;
+
+    // Avoid division by zero (shouldn't happen but be safe)
+    if (dt <= 0) {
+      return before;
+    }
+
+    // Interpolation factor (0 = before, 1 = after)
+    const alpha = Math.min(1, Math.max(0, (targetServerTime - t1) / dt));
+
+    // Linear interpolation
+    return {
+      x: before.x + (after.x - before.x) * alpha,
+      y: before.y + (after.y - before.y) * alpha,
+      z: before.z + (after.z - before.z) * alpha,
+      vx: before.vx + (after.vx - before.vx) * alpha,
+      vy: before.vy + (after.vy - before.vy) * alpha,
+      vz: before.vz + (after.vz - before.vz) * alpha,
+      serverTime: before.serverTime + (after.serverTime - before.serverTime) * alpha,
+      clientTime: playbackTime,
+    };
+  }
+
+  /**
+   * Remove an entity's buffer (when entity is destroyed).
+   */
+  remove(entityId: string): void {
+    this.buffers.delete(entityId);
+    this.clockOffsets.delete(entityId);
+  }
+
+  /**
+   * Clear all buffers (e.g., on reconnect).
+   */
+  clear(): void {
+    this.buffers.clear();
+    this.clockOffsets.clear();
+    this.underrunCount = 0;
+  }
+
+  /**
+   * Set the buffer delay (playback lag).
+   * Higher values = more jitter resistance but more latency.
+   */
+  setBufferDelay(ms: number): void {
+    this.bufferDelay = Math.max(0, ms);
+  }
+
+  /**
+   * Get the current buffer delay setting.
+   */
+  getBufferDelay(): number {
+    return this.bufferDelay;
+  }
+
+  /**
+   * Get buffer statistics for diagnostics.
+   */
+  getStats(): BufferStats {
+    let totalSnapshots = 0;
+    let entityCount = 0;
+
+    this.buffers.forEach((buffer) => {
+      totalSnapshots += buffer.length;
+      entityCount++;
+    });
+
+    return {
+      entityCount,
+      avgOccupancy: entityCount > 0 ? totalSnapshots / entityCount : 0,
+      underrunCount: this.underrunCount,
+      currentDelay: this.bufferDelay,
+    };
+  }
+
+  /**
+   * Reset underrun count (for periodic stats logging).
+   */
+  resetUnderrunCount(): void {
+    this.underrunCount = 0;
+  }
+
+  /**
+   * Check if buffer has data for an entity.
+   */
+  hasEntity(entityId: string): boolean {
+    const buffer = this.buffers.get(entityId);
+    return buffer !== undefined && buffer.length > 0;
+  }
+
+  /**
+   * Get raw buffer size for an entity (for debugging).
+   */
+  getBufferSize(entityId: string): number {
+    const buffer = this.buffers.get(entityId);
+    return buffer ? buffer.length : 0;
+  }
+}

--- a/client/src/core/net/SocketManager.ts
+++ b/client/src/core/net/SocketManager.ts
@@ -120,12 +120,9 @@ export class SocketManager {
   // Snapshot buffer for jitter compensation
   private snapshotBuffer: SnapshotBuffer = new SnapshotBuffer();
 
-  // Network timing diagnostics
+  // Network timing tracking (for buffer population)
   private lastMoveTime: Map<string, number> = new Map();
   private lastServerTime: Map<string, number> = new Map();
-  private moveDeltas: number[] = [];
-  private serverDeltas: number[] = [];
-  private lastDiagnosticLog = 0;
 
   constructor(serverUrl: string, world: World, isPlaygroundParam = false, isSpectatorParam = false) {
     this.world = world;
@@ -471,61 +468,8 @@ export class SocketManager {
         }
       }
 
-      // Network timing diagnostics - track time between updates for local player
+      // Track timing for local player (used by buffer)
       if (data.playerId === this._myPlayerId) {
-        const lastClientTime = this.lastMoveTime.get(data.playerId);
-        const lastServerTime = this.lastServerTime.get(data.playerId);
-
-        if (lastClientTime && data.serverTime && lastServerTime) {
-          const clientDelta = now - lastClientTime;
-          const serverDelta = data.serverTime - lastServerTime;
-          this.moveDeltas.push(clientDelta);
-          this.serverDeltas.push(serverDelta);
-
-          // Log if gap is >50ms (3x expected 16.67ms tick)
-          if (clientDelta > 50) {
-            // Compare: did server send late, or did network deliver late?
-            const blame = serverDelta > 25 ? 'SERVER' : 'NETWORK';
-            console.warn(`[NETJITTER] Gap: ${clientDelta.toFixed(0)}ms (server delta: ${serverDelta.toFixed(0)}ms) → ${blame}`);
-          }
-
-          // Every 2 seconds, log stats and reset
-          if (now - this.lastDiagnosticLog > 2000) {
-            const sortedClient = [...this.moveDeltas].sort((a, b) => a - b);
-            const sortedServer = [...this.serverDeltas].sort((a, b) => a - b);
-
-            const clientAvg = sortedClient.reduce((a, b) => a + b, 0) / sortedClient.length;
-            const clientMax = sortedClient[sortedClient.length - 1];
-            const clientP95 = sortedClient[Math.floor(sortedClient.length * 0.95)] || clientMax;
-
-            const serverAvg = sortedServer.reduce((a, b) => a + b, 0) / sortedServer.length;
-            const serverMax = sortedServer[sortedServer.length - 1];
-            const serverP95 = sortedServer[Math.floor(sortedServer.length * 0.95)] || serverMax;
-
-            const clientGaps = this.moveDeltas.filter((d) => d > 50).length;
-            const serverGaps = this.serverDeltas.filter((d) => d > 25).length;
-
-            // Include buffer stats in diagnostics
-            const bufferStats = this.snapshotBuffer.getStats();
-            console.log(
-              `[NETDIAG] Client: Avg=${clientAvg.toFixed(1)}ms Max=${clientMax.toFixed(0)}ms P95=${clientP95.toFixed(0)}ms Gaps=${clientGaps}`
-            );
-            console.log(
-              `[NETDIAG] Server: Avg=${serverAvg.toFixed(1)}ms Max=${serverMax.toFixed(0)}ms P95=${serverP95.toFixed(0)}ms Gaps=${serverGaps}`
-            );
-            console.log(
-              `[NETDIAG] Buffer: Delay=${bufferStats.currentDelay}ms Entities=${bufferStats.entityCount} AvgOccupancy=${bufferStats.avgOccupancy.toFixed(1)} Underruns=${bufferStats.underrunCount}`
-            );
-            console.log(
-              `[NETDIAG] Verdict: ${serverGaps > 0 ? 'SERVER sending late' : clientGaps > 0 ? 'NETWORK delivering late' : 'OK'}`
-            );
-
-            this.moveDeltas = [];
-            this.serverDeltas = [];
-            this.snapshotBuffer.resetUnderrunCount();
-            this.lastDiagnosticLog = now;
-          }
-        }
         this.lastMoveTime.set(data.playerId, now);
         if (data.serverTime) {
           this.lastServerTime.set(data.playerId, data.serverTime);
@@ -891,11 +835,7 @@ export class SocketManager {
     }
     // Stage 3+ macro-resources (optional in message)
     if (snapshot.dataFruits) {
-      const fruitCount = Object.keys(snapshot.dataFruits).length;
-      console.log('[DEBUG] applySnapshot: received dataFruits count:', fruitCount);
       Object.values(snapshot.dataFruits).forEach((f) => upsertDataFruit(this.world, f));
-    } else {
-      console.log('[DEBUG] applySnapshot: NO dataFruits in snapshot');
     }
     if (snapshot.cyberBugs) {
       Object.values(snapshot.cyberBugs).forEach((b) => upsertCyberBug(this.world, b));

--- a/client/src/core/net/SocketManager.ts
+++ b/client/src/core/net/SocketManager.ts
@@ -3,6 +3,7 @@
 // ============================================
 
 import { io, Socket } from 'socket.io-client';
+import { SnapshotBuffer, type Snapshot } from './SnapshotBuffer';
 import type {
   WorldSnapshotMessage,
   PlayerJoinedMessage,
@@ -63,7 +64,6 @@ import {
   Tags,
   Components,
   upsertPlayer,
-  updatePlayerTarget,
   removePlayer,
   updatePlayerEnergy,
   setPlayerEvolving,
@@ -85,6 +85,7 @@ import {
   setLocalPlayer,
   clearLookups,
   getStringIdByEntity,
+  getEntityByStringId,
   // Stage 3+ macro-resource factories
   upsertDataFruit,
   removeDataFruit,
@@ -100,6 +101,7 @@ import {
   removeTrap,
   upsertEntropySerpent,
   updateEntropySerpentPosition,
+  type VelocityComponent,
 } from '../../ecs';
 import { eventBus } from '../events/EventBus';
 
@@ -114,6 +116,9 @@ export class SocketManager {
 
   // Local player's combat specialization (Stage 3+)
   private _mySpecialization: CombatSpecialization = null;
+
+  // Snapshot buffer for jitter compensation
+  private snapshotBuffer: SnapshotBuffer = new SnapshotBuffer();
 
   // Network timing diagnostics
   private lastMoveTime: Map<string, number> = new Map();
@@ -189,6 +194,14 @@ export class SocketManager {
    */
   getMySpecialization(): CombatSpecialization {
     return this._mySpecialization;
+  }
+
+  /**
+   * Get the snapshot buffer for position interpolation.
+   * PlayerRenderSystem uses this to query buffered positions.
+   */
+  getSnapshotBuffer(): SnapshotBuffer {
+    return this.snapshotBuffer;
   }
 
   /**
@@ -429,9 +442,37 @@ export class SocketManager {
     });
 
     this.socket.on('playerMoved', (data: PlayerMovedMessage) => {
+      const now = performance.now();
+
+      // Push snapshot to jitter buffer (delayed playback)
+      const snapshot: Snapshot = {
+        x: data.position.x,
+        y: data.position.y,
+        z: data.position.z ?? 0,
+        vx: data.velocity?.x ?? 0,
+        vy: data.velocity?.y ?? 0,
+        vz: data.velocity?.z ?? 0,
+        serverTime: data.serverTime ?? now,
+        clientTime: now,
+      };
+      this.snapshotBuffer.push(data.playerId, snapshot);
+
+      // Still update velocity directly for visual effects (trails, animations)
+      // Position comes from buffer, but velocity is used immediately
+      if (data.velocity) {
+        const entity = getEntityByStringId(data.playerId);
+        if (entity !== undefined) {
+          const vel = this.world.getComponent<VelocityComponent>(entity, Components.Velocity);
+          if (vel) {
+            vel.x = data.velocity.x;
+            vel.y = data.velocity.y;
+            vel.z = data.velocity.z ?? 0;
+          }
+        }
+      }
+
       // Network timing diagnostics - track time between updates for local player
       if (data.playerId === this._myPlayerId) {
-        const now = performance.now();
         const lastClientTime = this.lastMoveTime.get(data.playerId);
         const lastServerTime = this.lastServerTime.get(data.playerId);
 
@@ -461,15 +502,27 @@ export class SocketManager {
             const serverMax = sortedServer[sortedServer.length - 1];
             const serverP95 = sortedServer[Math.floor(sortedServer.length * 0.95)] || serverMax;
 
-            const clientGaps = this.moveDeltas.filter(d => d > 50).length;
-            const serverGaps = this.serverDeltas.filter(d => d > 25).length;
+            const clientGaps = this.moveDeltas.filter((d) => d > 50).length;
+            const serverGaps = this.serverDeltas.filter((d) => d > 25).length;
 
-            console.log(`[NETDIAG] Client: Avg=${clientAvg.toFixed(1)}ms Max=${clientMax.toFixed(0)}ms P95=${clientP95.toFixed(0)}ms Gaps=${clientGaps}`);
-            console.log(`[NETDIAG] Server: Avg=${serverAvg.toFixed(1)}ms Max=${serverMax.toFixed(0)}ms P95=${serverP95.toFixed(0)}ms Gaps=${serverGaps}`);
-            console.log(`[NETDIAG] Verdict: ${serverGaps > 0 ? 'SERVER sending late' : clientGaps > 0 ? 'NETWORK delivering late' : 'OK'}`);
+            // Include buffer stats in diagnostics
+            const bufferStats = this.snapshotBuffer.getStats();
+            console.log(
+              `[NETDIAG] Client: Avg=${clientAvg.toFixed(1)}ms Max=${clientMax.toFixed(0)}ms P95=${clientP95.toFixed(0)}ms Gaps=${clientGaps}`
+            );
+            console.log(
+              `[NETDIAG] Server: Avg=${serverAvg.toFixed(1)}ms Max=${serverMax.toFixed(0)}ms P95=${serverP95.toFixed(0)}ms Gaps=${serverGaps}`
+            );
+            console.log(
+              `[NETDIAG] Buffer: Delay=${bufferStats.currentDelay}ms Entities=${bufferStats.entityCount} AvgOccupancy=${bufferStats.avgOccupancy.toFixed(1)} Underruns=${bufferStats.underrunCount}`
+            );
+            console.log(
+              `[NETDIAG] Verdict: ${serverGaps > 0 ? 'SERVER sending late' : clientGaps > 0 ? 'NETWORK delivering late' : 'OK'}`
+            );
 
             this.moveDeltas = [];
             this.serverDeltas = [];
+            this.snapshotBuffer.resetUnderrunCount();
             this.lastDiagnosticLog = now;
           }
         }
@@ -479,14 +532,6 @@ export class SocketManager {
         }
       }
 
-      updatePlayerTarget(
-        this.world,
-        data.playerId,
-        data.position.x,
-        data.position.y,
-        data.position.z,
-        data.velocity
-      );
       eventBus.emit(data);
     });
 
@@ -551,6 +596,22 @@ export class SocketManager {
     });
 
     this.socket.on('swarmMoved', (data: SwarmMovedMessage) => {
+      const now = performance.now();
+
+      // Push to jitter buffer for smooth interpolation
+      const snapshot: Snapshot = {
+        x: data.position.x,
+        y: data.position.y,
+        z: data.position.z ?? 0,
+        vx: 0, // Swarms don't have velocity in message
+        vy: 0,
+        vz: 0,
+        serverTime: data.serverTime ?? now,
+        clientTime: now,
+      };
+      this.snapshotBuffer.push(data.swarmId, snapshot);
+
+      // Still update ECS for non-position data (state, energy, disabledUntil)
       updateSwarmTarget(
         this.world,
         data.swarmId,
@@ -646,6 +707,22 @@ export class SocketManager {
     });
 
     this.socket.on('cyberBugMoved', (data: CyberBugMovedMessage) => {
+      const now = performance.now();
+
+      // Push to jitter buffer for smooth interpolation
+      const snapshot: Snapshot = {
+        x: data.position.x,
+        y: data.position.y,
+        z: 0,
+        vx: 0,
+        vy: 0,
+        vz: 0,
+        serverTime: data.serverTime ?? now,
+        clientTime: now,
+      };
+      this.snapshotBuffer.push(data.bugId, snapshot);
+
+      // Still update ECS for state
       updateCyberBugPosition(this.world, data.bugId, data.position.x, data.position.y, data.state);
     });
 
@@ -661,6 +738,22 @@ export class SocketManager {
     });
 
     this.socket.on('jungleCreatureMoved', (data: JungleCreatureMovedMessage) => {
+      const now = performance.now();
+
+      // Push to jitter buffer for smooth interpolation
+      const snapshot: Snapshot = {
+        x: data.position.x,
+        y: data.position.y,
+        z: 0,
+        vx: 0,
+        vy: 0,
+        vz: 0,
+        serverTime: data.serverTime ?? now,
+        clientTime: now,
+      };
+      this.snapshotBuffer.push(data.creatureId, snapshot);
+
+      // Still update ECS for state
       updateJungleCreaturePosition(
         this.world,
         data.creatureId,
@@ -672,6 +765,22 @@ export class SocketManager {
 
     // EntropySerpent events (jungle apex predator)
     this.socket.on('entropySerpentMoved', (data: EntropySerpentMovedMessage) => {
+      const now = performance.now();
+
+      // Push to jitter buffer for smooth interpolation
+      const snapshot: Snapshot = {
+        x: data.position.x,
+        y: data.position.y,
+        z: 0,
+        vx: 0,
+        vy: 0,
+        vz: 0,
+        serverTime: data.serverTime ?? now,
+        clientTime: now,
+      };
+      this.snapshotBuffer.push(data.serpentId, snapshot);
+
+      // Still update ECS for state and heading
       updateEntropySerpentPosition(
         this.world,
         data.serpentId,
@@ -828,6 +937,9 @@ export class SocketManager {
 
     // Clear string ID lookups
     clearLookups();
+
+    // Clear snapshot buffer
+    this.snapshotBuffer.clear();
   }
 
   /**

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -165,6 +165,9 @@ function initializeGame(settings: PreGameSettings): void {
   const container = document.getElementById('game-container')!;
   renderer.init(container, GAME_CONFIG.VIEWPORT_WIDTH, GAME_CONFIG.VIEWPORT_HEIGHT, world);
 
+  // Wire snapshot buffer from SocketManager to renderer (for jitter-compensated interpolation)
+  renderer.setSnapshotBuffer(socketManager.getSnapshotBuffer());
+
   // Expose debug toggles to window for console access
   // Usage: window.debugSerpent() - toggles serpent head/body/attack visualization
   (window as unknown as { debugSerpent: () => boolean }).debugSerpent = () =>

--- a/client/src/render/systems/CyberBugRenderSystem.ts
+++ b/client/src/render/systems/CyberBugRenderSystem.ts
@@ -21,6 +21,7 @@ import {
   updateCyberBugState,
   disposeCyberBug,
 } from '../meshes/CyberBugMesh';
+import type { SnapshotBuffer } from '../../core/net/SnapshotBuffer';
 
 /**
  * CyberBugRenderSystem - Manages cyber bug rendering
@@ -42,6 +43,16 @@ export class CyberBugRenderSystem {
   // Animation data
   private animationPhase: Map<string, number> = new Map();
   private wingFlutter: Map<string, number> = new Map();
+
+  // Snapshot buffer for jitter-compensated interpolation (set externally)
+  private snapshotBuffer: SnapshotBuffer | null = null;
+
+  /**
+   * Set the snapshot buffer for jitter-compensated position interpolation.
+   */
+  setSnapshotBuffer(buffer: SnapshotBuffer): void {
+    this.snapshotBuffer = buffer;
+  }
 
   /**
    * Initialize system with scene and world references
@@ -92,8 +103,22 @@ export class CyberBugRenderSystem {
       }
 
       // Update target position
-      const targetX = interp ? interp.targetX : pos.x;
-      const targetY = interp ? interp.targetY : pos.y;
+      // Priority: snapshot buffer (jitter-compensated) > interp component > raw position
+      let targetX = pos.x;
+      let targetY = pos.y;
+
+      if (this.snapshotBuffer && this.snapshotBuffer.hasEntity(bugId)) {
+        const playbackTime = performance.now() - this.snapshotBuffer.getBufferDelay();
+        const bufferedPos = this.snapshotBuffer.getInterpolated(bugId, playbackTime);
+        if (bufferedPos) {
+          targetX = bufferedPos.x;
+          targetY = bufferedPos.y;
+        }
+      } else if (interp) {
+        targetX = interp.targetX;
+        targetY = interp.targetY;
+      }
+
       this.bugTargets.set(bugId, { x: targetX, y: targetY });
 
       // Update state-based visuals (color changes when fleeing)

--- a/client/src/render/systems/EntropySerpentRenderSystem.ts
+++ b/client/src/render/systems/EntropySerpentRenderSystem.ts
@@ -23,6 +23,7 @@ import {
   disposeEntropySerpent,
   triggerClawSwipe,
 } from '../meshes/EntropySerpentMesh';
+import type { SnapshotBuffer } from '../../core/net/SnapshotBuffer';
 
 /**
  * EntropySerpentRenderSystem - Manages entropy serpent rendering
@@ -50,6 +51,16 @@ export class EntropySerpentRenderSystem {
   private debugMarkers: Map<string, THREE.Group> = new Map();
   private _lastDebugLog = 0;
   private _lastPosLogs: Map<string, number> = new Map();
+
+  // Snapshot buffer for jitter-compensated interpolation (set externally)
+  private snapshotBuffer: SnapshotBuffer | null = null;
+
+  /**
+   * Set the snapshot buffer for jitter-compensated position interpolation.
+   */
+  setSnapshotBuffer(buffer: SnapshotBuffer): void {
+    this.snapshotBuffer = buffer;
+  }
 
   /**
    * Initialize system with scene and world references
@@ -104,8 +115,22 @@ export class EntropySerpentRenderSystem {
       }
 
       // Update target position
-      const targetX = interp ? interp.targetX : pos.x;
-      const targetY = interp ? interp.targetY : pos.y;
+      // Priority: snapshot buffer (jitter-compensated) > interp component > raw position
+      let targetX = pos.x;
+      let targetY = pos.y;
+
+      if (this.snapshotBuffer && this.snapshotBuffer.hasEntity(serpentId)) {
+        const playbackTime = performance.now() - this.snapshotBuffer.getBufferDelay();
+        const bufferedPos = this.snapshotBuffer.getInterpolated(serpentId, playbackTime);
+        if (bufferedPos) {
+          targetX = bufferedPos.x;
+          targetY = bufferedPos.y;
+        }
+      } else if (interp) {
+        targetX = interp.targetX;
+        targetY = interp.targetY;
+      }
+
       this.serpentTargets.set(serpentId, { x: targetX, y: targetY });
 
       // Update heading

--- a/client/src/render/systems/JungleCreatureRenderSystem.ts
+++ b/client/src/render/systems/JungleCreatureRenderSystem.ts
@@ -21,7 +21,6 @@ import {
   updateJungleCreatureState,
   disposeJungleCreature,
 } from '../meshes/JungleCreatureMesh';
-import type { SnapshotBuffer } from '../../core/net/SnapshotBuffer';
 
 /**
  * JungleCreatureRenderSystem - Manages jungle creature rendering
@@ -45,16 +44,6 @@ export class JungleCreatureRenderSystem {
 
   // Animation data
   private animationPhase: Map<string, number> = new Map();
-
-  // Snapshot buffer for jitter-compensated interpolation (set externally)
-  private snapshotBuffer: SnapshotBuffer | null = null;
-
-  /**
-   * Set the snapshot buffer for jitter-compensated position interpolation.
-   */
-  setSnapshotBuffer(buffer: SnapshotBuffer): void {
-    this.snapshotBuffer = buffer;
-  }
 
   /**
    * Initialize system with scene and world references
@@ -107,23 +96,9 @@ export class JungleCreatureRenderSystem {
         this.animationPhase.set(creatureId, Math.random() * Math.PI * 2);
       }
 
-      // Update target position
-      // Priority: snapshot buffer (jitter-compensated) > interp component > raw position
-      let targetX = pos.x;
-      let targetY = pos.y;
-
-      if (this.snapshotBuffer && this.snapshotBuffer.hasEntity(creatureId)) {
-        const playbackTime = performance.now() - this.snapshotBuffer.getBufferDelay();
-        const bufferedPos = this.snapshotBuffer.getInterpolated(creatureId, playbackTime);
-        if (bufferedPos) {
-          targetX = bufferedPos.x;
-          targetY = bufferedPos.y;
-        }
-      } else if (interp) {
-        targetX = interp.targetX;
-        targetY = interp.targetY;
-      }
-
+      // Update target position from InterpolationTarget (buffer updates this centrally)
+      const targetX = interp?.targetX ?? pos.x;
+      const targetY = interp?.targetY ?? pos.y;
       this.creatureTargets.set(creatureId, { x: targetX, y: targetY });
 
       // Update state-based visuals

--- a/client/src/render/three/ThreeRenderer.ts
+++ b/client/src/render/three/ThreeRenderer.ts
@@ -866,6 +866,9 @@ export class ThreeRenderer implements Renderer {
     // Interpolate swarm positions
     this.swarmRenderSystem.interpolate(dt);
 
+    // Sync aura positions to interpolated swarm positions (must be after interpolate)
+    this.swarmRenderSystem.syncAuraPositions();
+
     // Animate swarm particles
     this.swarmRenderSystem.updateAnimations(dt);
 
@@ -1273,6 +1276,20 @@ export class ThreeRenderer implements Renderer {
    */
   getCameraSystem(): CameraSystem {
     return this.cameraSystem;
+  }
+
+  /**
+   * Set snapshot buffer for jitter-compensated position interpolation.
+   * Pass-through to all render systems that support jitter buffering.
+   */
+  setSnapshotBuffer(
+    buffer: import('../../core/net/SnapshotBuffer').SnapshotBuffer
+  ): void {
+    this.playerRenderSystem.setSnapshotBuffer(buffer);
+    this.swarmRenderSystem.setSnapshotBuffer(buffer);
+    this.cyberBugRenderSystem.setSnapshotBuffer(buffer);
+    this.jungleCreatureRenderSystem.setSnapshotBuffer(buffer);
+    this.entropySerpentRenderSystem.setSnapshotBuffer(buffer);
   }
 
   /**

--- a/client/src/render/three/ThreeRenderer.ts
+++ b/client/src/render/three/ThreeRenderer.ts
@@ -34,13 +34,16 @@ import {
   Tags,
   Components,
   getStringIdByEntity,
+  getEntityByStringId,
   getLocalPlayerId,
   getLocalPlayer,
   getPlayer,
   forEachPlayer,
   type PositionComponent,
   type ObstacleComponent,
+  type InterpolationTargetComponent,
 } from '../../ecs';
+import type { SnapshotBuffer } from '../../core/net/SnapshotBuffer';
 import { frameLerp } from '../../utils/math';
 import { applySphereVisibilityCulling } from '../utils/SphereRenderUtils';
 
@@ -115,6 +118,9 @@ export class ThreeRenderer implements Renderer {
 
   // Wake particle system (liquid wake effect behind moving entities)
   private wakeParticleSystem!: WakeParticleSystem;
+
+  // Snapshot buffer for jitter-compensated position interpolation
+  private snapshotBuffer: SnapshotBuffer | null = null;
 
   // EventBus subscriptions for cleanup (prevents memory leaks)
   private eventSubscriptions: Array<() => void> = [];
@@ -834,6 +840,10 @@ export class ThreeRenderer implements Renderer {
     // Update all particle effects (death, evolution, EMP, spawn, energy transfer)
     const { spawnProgress } = this.effectsSystem.update(dt);
 
+    // Apply buffered positions to ECS InterpolationTarget components
+    // This centralizes jitter buffer queries - render systems just read ECS
+    this.applyBufferedPositions();
+
     // Sync all entities (systems query World directly)
     this.playerRenderSystem.sync(this.environmentSystem.getMode(), this.cameraSystem.getYaw(), dt);
     this.nutrientRenderSystem.sync(this.environmentSystem.getMode());
@@ -1280,16 +1290,43 @@ export class ThreeRenderer implements Renderer {
 
   /**
    * Set snapshot buffer for jitter-compensated position interpolation.
-   * Pass-through to all render systems that support jitter buffering.
+   * Buffer is used centrally to update ECS InterpolationTarget components.
+   * PlayerRenderSystem still gets direct access for stage-specific handling.
    */
-  setSnapshotBuffer(
-    buffer: import('../../core/net/SnapshotBuffer').SnapshotBuffer
-  ): void {
+  setSnapshotBuffer(buffer: SnapshotBuffer): void {
+    this.snapshotBuffer = buffer;
+    // PlayerRenderSystem has special stage-based handling, so it gets direct access
     this.playerRenderSystem.setSnapshotBuffer(buffer);
+    // Swarm also gets direct access for its special SLERP handling
     this.swarmRenderSystem.setSnapshotBuffer(buffer);
-    this.cyberBugRenderSystem.setSnapshotBuffer(buffer);
-    this.jungleCreatureRenderSystem.setSnapshotBuffer(buffer);
-    this.entropySerpentRenderSystem.setSnapshotBuffer(buffer);
+  }
+
+  /**
+   * Apply buffered positions to ECS InterpolationTarget components.
+   * Called once per frame before render systems sync.
+   * This centralizes buffer queries instead of having each render system do it.
+   */
+  private applyBufferedPositions(): void {
+    if (!this.snapshotBuffer) return;
+
+    const playbackTime = performance.now() - this.snapshotBuffer.getBufferDelay();
+
+    this.snapshotBuffer.forEachInterpolated(playbackTime, (entityId, interpolated) => {
+      const entity = getEntityByStringId(entityId);
+      if (!entity) return;
+
+      const interp = this.world.getComponent<InterpolationTargetComponent>(
+        entity,
+        Components.InterpolationTarget
+      );
+      if (interp) {
+        interp.targetX = interpolated.x;
+        interp.targetY = interpolated.y;
+        if (interpolated.z !== undefined) {
+          interp.targetZ = interpolated.z;
+        }
+      }
+    });
   }
 
   /**

--- a/server/src/ecs/systems/CyberBugAISystem.ts
+++ b/server/src/ecs/systems/CyberBugAISystem.ts
@@ -205,6 +205,7 @@ export class CyberBugAISystem implements System {
     const jungleMinY = 0;
     const jungleMaxY = GAME_CONFIG.JUNGLE_HEIGHT;
 
+    const serverTime = Date.now();
     forEachCyberBug(world, (entity, bugId, posComp, bugComp) => {
       const velComp = world.getComponent<VelocityComponent>(entity, Components.Velocity);
       if (!velComp) return;
@@ -224,6 +225,7 @@ export class CyberBugAISystem implements System {
         bugId,
         position: { x: posComp.x, y: posComp.y },
         state: bugComp.state,
+        serverTime,
       };
       io.emit('cyberBugMoved', movedMessage);
     });

--- a/server/src/ecs/systems/EntropySerpentAISystem.ts
+++ b/server/src/ecs/systems/EntropySerpentAISystem.ts
@@ -67,6 +67,7 @@ export class EntropySerpentAISystem implements System {
     }
 
     // Update living serpents
+    const serverTime = Date.now();
     forEachEntropySerpent(world, (entity, id, pos, vel, serpent) => {
       // Find nearest Stage 3+ player (target)
       const target = this.findNearestTarget(world, pos.x, pos.y);
@@ -187,6 +188,7 @@ export class EntropySerpentAISystem implements System {
         state: serpent.state,
         heading: serpent.heading,
         targetPlayerId,
+        serverTime,
       };
       io.emit('entropySerpentMoved', movedMessage);
     });

--- a/server/src/ecs/systems/JungleCreatureAISystem.ts
+++ b/server/src/ecs/systems/JungleCreatureAISystem.ts
@@ -442,6 +442,7 @@ export class JungleCreatureAISystem implements System {
     const jungleMinY = 0;
     const jungleMaxY = GAME_CONFIG.JUNGLE_HEIGHT;
 
+    const serverTime = Date.now();
     forEachJungleCreature(world, (entity, creatureId, posComp, creatureComp) => {
       const velComp = world.getComponent<VelocityComponent>(entity, Components.Velocity);
       if (!velComp) return;
@@ -462,6 +463,7 @@ export class JungleCreatureAISystem implements System {
         position: { x: posComp.x, y: posComp.y },
         state: creatureComp.state,
         variant: creatureComp.variant,
+        serverTime,
       };
       io.emit('jungleCreatureMoved', movedMessage);
     });

--- a/server/src/ecs/systems/NetworkBroadcastSystem.ts
+++ b/server/src/ecs/systems/NetworkBroadcastSystem.ts
@@ -249,6 +249,7 @@ export class NetworkBroadcastSystem implements System {
    * Sends position, state, and energy for interpolation and visual scaling
    */
   private broadcastSwarmPositionUpdates(world: World, io: Server): void {
+    const serverTime = Date.now();
     forEachSwarm(world, (_entity, swarmId, posComp, _velComp, swarmComp, energyComp) => {
       const moveMessage: SwarmMovedMessage = {
         type: 'swarmMoved',
@@ -257,6 +258,7 @@ export class NetworkBroadcastSystem implements System {
         state: swarmComp.state,
         disabledUntil: swarmComp.disabledUntil,
         energy: energyComp?.current,
+        serverTime,
       };
       io.emit('swarmMoved', moveMessage);
     });

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -212,6 +212,7 @@ export interface SwarmMovedMessage {
   state: 'patrol' | 'chase';
   disabledUntil?: number; // Timestamp when EMP stun expires (if disabled)
   energy?: number; // Current energy for visual scaling (swarms grow as they drain)
+  serverTime?: number; // Server timestamp for jitter buffer interpolation
 }
 
 export interface PseudopodSpawnedMessage {
@@ -352,6 +353,7 @@ export interface CyberBugMovedMessage {
   bugId: string;
   position: Position;
   state: string; // 'idle' | 'patrol' | 'flee'
+  serverTime?: number; // Server timestamp for jitter buffer interpolation
 }
 
 // JungleCreature spawn/kill messages
@@ -375,6 +377,7 @@ export interface JungleCreatureMovedMessage {
   position: Position;
   state: string; // 'idle' | 'patrol' | 'hunt' | 'flee'
   variant: string; // 'grazer' | 'stalker' | 'ambusher'
+  serverTime?: number; // Server timestamp for jitter buffer interpolation
 }
 
 // EntropySerpent spawn/move messages
@@ -390,6 +393,7 @@ export interface EntropySerpentMovedMessage {
   state: 'patrol' | 'chase' | 'attack';
   heading: number;
   targetPlayerId?: string;
+  serverTime?: number; // Server timestamp for jitter buffer interpolation
 }
 
 export interface EntropySerpentAttackMessage {


### PR DESCRIPTION
## Summary
- Add SnapshotBuffer for jitter-compensated position interpolation
- Use SLERP for swarm movement on sphere surface (matches player movement)
- Sync aura positions after interpolation to prevent one-frame lag
- Add snapshot buffer support to all entity render systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side snapshot buffering and interpolation for smoother, more consistent entity and player movement rendering.
  * Renderer and render systems now consume buffered positions; swarm aura positions synchronized with interpolated swarm movement.
  * Server movement messages now include server timestamps to improve client-side timing accuracy.

* **Chores**
  * Snapshot buffer lifecycle tied to connection/reset to ensure clean state on disconnect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->